### PR TITLE
feat: 마크다운 렌더링에서 URL의 OpenGraph 정보를 카드 형태의 컴포넌트로 렌더링

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,50 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## 📎 외부 링크 프리뷰 (Link Preview)
+
+마크다운 내 외부 URL을 카드 형태로 렌더링합니다. Open Graph 메타데이터를 서버에서 스크랩하여 제목, 설명, 이미지를 표시합니다.
+
+### 사용법
+
+**1. 베어 URL (자동 감지)**
+
+URL만 단독으로 한 줄에 작성하면 자동으로 카드로 변환됩니다:
+
+```md
+참고 자료입니다:
+
+https://nextjs.org/docs/app
+
+위 내용을 참고하세요.
+```
+
+> `[텍스트](url)` 형태의 인라인 링크는 항상 일반 텍스트 링크로 유지됩니다.
+
+**2. 링크 + 카드 렌더링: `<!-- og -->`**
+
+```md
+<!-- og -->
+https://nextjs.org/docs/app
+```
+
+원래 링크를 유지하고, 아래에 OG 카드를 추가로 표시합니다.
+
+**3. 카드만 렌더링: `<!-- og-only -->`**
+
+```md
+<!-- og-only -->
+https://nextjs.org/docs/app
+```
+
+원래 링크를 숨기고 OG 카드만 표시합니다.
+
+**4. 카드 렌더링 제외: `<!-- no-og -->`**
+
+```md
+<!-- no-og -->
+https://example.com
+```
+
+베어 URL이어도 카드 렌더링을 하지 않고 일반 링크로 표시합니다.

--- a/contents/posts/9univ-react-study/01-react-basic-with-clone-coding/content.md
+++ b/contents/posts/9univ-react-study/01-react-basic-with-clone-coding/content.md
@@ -10,6 +10,9 @@ seriesIndex: 0
 
 노마드 코더님의 [ReactJS로 영화 웹 서비스 만들기](https://nomadcoders.co/react-for-beginners/)를 들으며 방학동안 리액트 기본문법을 배운 후 이번주는 Todo리스트, 코인 트래커를 따라 만들어보았습니다.
 
+<!-- og -->
+https://nomadcoders.co/react-for-beginners/
+
 원래는 영화 서비스 페이지도 클론코딩해볼 계획이였으나, 개강 첫주라 시간이 부족했었습니다. 또한 전체적인 학습 계획을 조금 수정해보았습니다.
 
 [README.md](https://github.com/karpitony/9oormthonUniv-React-Study/blob/main/README.md)에 주차별로 어떤 내용을 배울지 업데이트 해봤습니다.

--- a/contents/posts/dev/250715-timetable-wizard-for-2500-students/content.md
+++ b/contents/posts/dev/250715-timetable-wizard-for-2500-students/content.md
@@ -21,7 +21,14 @@ draft: false
 > 추후 데이터 포맷이 유사하다면 확장도 가능하겠지만, 우선은 제 학교 중심으로 빠르게 만들어보는 데 집중했습니다.
 
 - 🚀 서비스 바로가기: https://timetable-wizard.vercel.app
+
+<!-- og-only-->
+https://timetable-wizard.vercel.app
+
 - 🛠 GitHub 저장소: https://github.com/karpitony/timetable-wizard
+
+<!-- og-only -->
+https://github.com/karpitony/timetable-wizard
 
 ## 기획 배경
 

--- a/src/app/api/og/route.ts
+++ b/src/app/api/og/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+interface OgData {
+  title: string;
+  description: string;
+  image: string;
+  favicon: string;
+  siteName: string;
+}
+
+function extractMetaContent(html: string, property: string): string {
+  // Match both property="og:..." and name="..." patterns
+  const patterns = [
+    new RegExp(
+      `<meta[^>]*property=["']${property}["'][^>]*content=["']([^"']*)["']`,
+      'i',
+    ),
+    new RegExp(
+      `<meta[^>]*content=["']([^"']*)["'][^>]*property=["']${property}["']`,
+      'i',
+    ),
+    new RegExp(
+      `<meta[^>]*name=["']${property}["'][^>]*content=["']([^"']*)["']`,
+      'i',
+    ),
+    new RegExp(
+      `<meta[^>]*content=["']([^"']*)["'][^>]*name=["']${property}["']`,
+      'i',
+    ),
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) return match[1];
+  }
+  return '';
+}
+
+function extractTitle(html: string): string {
+  const match = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+  return match?.[1]?.trim() || '';
+}
+
+function resolveUrl(base: string, relative: string): string {
+  if (!relative) return '';
+  if (relative.startsWith('http')) return relative;
+  try {
+    return new URL(relative, base).href;
+  } catch {
+    return '';
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const url = request.nextUrl.searchParams.get('url');
+
+  if (!url) {
+    return NextResponse.json({ error: 'url parameter is required' }, { status: 400 });
+  }
+
+  try {
+    new URL(url);
+  } catch {
+    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (compatible; Yuniversebot/1.0; +https://yunseok.vercel.app)',
+        Accept: 'text/html',
+      },
+    });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      return NextResponse.json({ error: 'Failed to fetch URL' }, { status: 502 });
+    }
+
+    const html = await response.text();
+    const origin = new URL(url).origin;
+
+    const ogImage = extractMetaContent(html, 'og:image');
+    const favicon =
+      html.match(/<link[^>]*rel=["'](?:icon|shortcut icon)["'][^>]*href=["']([^"']*)["']/i)?.[1] ||
+      '/favicon.ico';
+
+    const data: OgData = {
+      title:
+        extractMetaContent(html, 'og:title') ||
+        extractMetaContent(html, 'twitter:title') ||
+        extractTitle(html),
+      description:
+        extractMetaContent(html, 'og:description') ||
+        extractMetaContent(html, 'twitter:description') ||
+        extractMetaContent(html, 'description'),
+      image: resolveUrl(url, ogImage),
+      favicon: resolveUrl(origin, favicon),
+      siteName: extractMetaContent(html, 'og:site_name') || new URL(url).hostname,
+    };
+
+    return NextResponse.json(data, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
+      },
+    });
+  } catch (err) {
+    console.error('OG fetch error:', err);
+    return NextResponse.json(
+      {
+        title: '',
+        description: '',
+        image: '',
+        favicon: '',
+        siteName: new URL(url).hostname,
+      } satisfies OgData,
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=36000',
+        },
+      },
+    );
+  }
+}

--- a/src/app/api/og/route.ts
+++ b/src/app/api/og/route.ts
@@ -11,22 +11,10 @@ interface OgData {
 function extractMetaContent(html: string, property: string): string {
   // Match both property="og:..." and name="..." patterns
   const patterns = [
-    new RegExp(
-      `<meta[^>]*property=["']${property}["'][^>]*content=["']([^"']*)["']`,
-      'i',
-    ),
-    new RegExp(
-      `<meta[^>]*content=["']([^"']*)["'][^>]*property=["']${property}["']`,
-      'i',
-    ),
-    new RegExp(
-      `<meta[^>]*name=["']${property}["'][^>]*content=["']([^"']*)["']`,
-      'i',
-    ),
-    new RegExp(
-      `<meta[^>]*content=["']([^"']*)["'][^>]*name=["']${property}["']`,
-      'i',
-    ),
+    new RegExp(`<meta[^>]*property=["']${property}["'][^>]*content=["']([^"']*)["']`, 'i'),
+    new RegExp(`<meta[^>]*content=["']([^"']*)["'][^>]*property=["']${property}["']`, 'i'),
+    new RegExp(`<meta[^>]*name=["']${property}["'][^>]*content=["']([^"']*)["']`, 'i'),
+    new RegExp(`<meta[^>]*content=["']([^"']*)["'][^>]*name=["']${property}["']`, 'i'),
   ];
 
   for (const pattern of patterns) {
@@ -71,8 +59,7 @@ export async function GET(request: NextRequest) {
     const response = await fetch(url, {
       signal: controller.signal,
       headers: {
-        'User-Agent':
-          'Mozilla/5.0 (compatible; Yuniversebot/1.0; +https://yunseok.vercel.app)',
+        'User-Agent': 'Mozilla/5.0 (compatible; Yuniversebot/1.0; +https://yunseok.vercel.app)',
         Accept: 'text/html',
       },
     });

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link';
-import { getPostList, getPostData } from '@/content/post.service';
+import { getPostList, getPostData, getSeriesContext, getPostNavContext } from '@/content/post.service';
 import { FiArrowLeft } from 'react-icons/fi';
 import MarkdownRender from '@/components/MarkdownRender';
 import TableOfContent from '@/components/MarkdownRender/TableOfContent';
 import Comments from '@/components/PostsPage/Comments';
+import SeriesNav from '@/components/PostsPage/SeriesNav';
+import PostNav from '@/components/PostsPage/PostNav';
 import cn from '@yeahx4/cn';
 
 export const dynamic = 'force-static';
@@ -42,6 +44,9 @@ export async function generateMetadata({ params }: PostPageProps) {
 export default async function PostPage({ params }: PostPageProps) {
   const { id } = await params;
   const { meta, body, originalFileName } = await getPostData(id);
+  const seriesContext = meta.series ? await getSeriesContext(meta.series, id) : null;
+  const postNavContext = await getPostNavContext(id);
+
   return (
     <>
       <div className="w-full mx-auto max-w-full md:max-w-3xl relative">
@@ -77,6 +82,8 @@ export default async function PostPage({ params }: PostPageProps) {
               {meta.series ? `${meta.series}` : 'No Series'}
             </p>
           </div>
+          {/* 시리즈 헤더 (제목 아래, 접혀있는 전체 목록) */}
+          {seriesContext && <SeriesNav context={seriesContext} variant="header" />}
         </div>
         <div className={cn('mt-12 md:mt-18')}>
           <MarkdownRender
@@ -85,6 +92,10 @@ export default async function PostPage({ params }: PostPageProps) {
             series={meta.series}
             renderType="POST"
           />
+          {/* 시리즈 네비게이션 (글 아래, 페이지네이션) */}
+          {seriesContext && <SeriesNav context={seriesContext} variant="footer" />}
+          {/* 전체 글 네비게이션 */}
+          <PostNav context={postNavContext} />
           <Comments />
         </div>
         <TableOfContent content={body.join('\n')} />
@@ -92,3 +103,4 @@ export default async function PostPage({ params }: PostPageProps) {
     </>
   );
 }
+

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,5 +1,10 @@
 import Link from 'next/link';
-import { getPostList, getPostData, getSeriesContext, getPostNavContext } from '@/content/post.service';
+import {
+  getPostList,
+  getPostData,
+  getSeriesContext,
+  getPostNavContext,
+} from '@/content/post.service';
 import { FiArrowLeft } from 'react-icons/fi';
 import MarkdownRender from '@/components/MarkdownRender';
 import TableOfContent from '@/components/MarkdownRender/TableOfContent';
@@ -103,4 +108,3 @@ export default async function PostPage({ params }: PostPageProps) {
     </>
   );
 }
-

--- a/src/components/MarkdownRender/LinkPreviewCard.tsx
+++ b/src/components/MarkdownRender/LinkPreviewCard.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import cn from '@yeahx4/cn';
+import { TbExternalLink } from 'react-icons/tb';
+
+interface OgData {
+  title: string;
+  description: string;
+  image: string;
+  favicon: string;
+  siteName: string;
+}
+
+interface LinkPreviewCardProps {
+  url: string;
+}
+
+export default function LinkPreviewCard({ url }: LinkPreviewCardProps) {
+  const [data, setData] = useState<OgData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const fetchOg = async () => {
+      try {
+        const res = await fetch(`/api/og?url=${encodeURIComponent(url)}`);
+        if (!res.ok) throw new Error('fetch failed');
+        const json: OgData = await res.json();
+        if (!json.title && !json.description) throw new Error('no data');
+        setData(json);
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchOg();
+  }, [url]);
+
+  // Loading skeleton
+  if (loading) {
+    return (
+      <div
+        className={cn(
+          'rounded-xl overflow-hidden my-4',
+          'border border-gray-200 dark:border-gray-700/50',
+          'bg-gray-50 dark:bg-gray-800/40',
+          'animate-pulse',
+        )}
+      >
+        <div className="flex flex-col md:flex-row">
+          <div className="md:w-[240px] h-[140px] md:h-auto bg-gray-200 dark:bg-gray-700/50 shrink-0" />
+          <div className="flex-1 p-4 space-y-3">
+            <div className="h-5 bg-gray-200 dark:bg-gray-700/50 rounded w-3/4" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700/50 rounded w-full" />
+            <div className="h-4 bg-gray-200 dark:bg-gray-700/50 rounded w-1/2" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error or no data — fallback to simple link
+  if (error || !data) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-400 hover:text-blue-300 transition-colors duration-200 items-center"
+      >
+        {url}
+        <TbExternalLink className="inline-block ml-1" aria-label="External link" />
+      </a>
+    );
+  }
+
+  const hostname = (() => {
+    try {
+      return new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+      return url;
+    }
+  })();
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        'group block rounded-xl overflow-hidden mt-2 mb-8 no-underline!',
+        'border border-gray-200 dark:border-gray-700/50',
+        'bg-white dark:bg-gray-800/40',
+        'hover:border-blue-400/50 dark:hover:border-blue-400/30',
+        'hover:shadow-lg hover:shadow-blue-500/5',
+        'transition-all duration-300 ease-out',
+      )}
+    >
+      <div className="flex flex-col md:flex-row">
+        {/* OG Image */}
+        {data.image && (
+          <div
+            className={cn(
+              'shrink-0 overflow-hidden',
+              'w-full md:w-[240px]',
+              'h-[160px] md:h-auto',
+              'bg-gray-100 dark:bg-gray-700/30',
+            )}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={data.image}
+              alt={data.title || 'Link preview'}
+              className={cn(
+                'w-full h-full object-cover m-0!',
+                'group-hover:scale-105 transition-transform duration-300',
+              )}
+              loading="lazy"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = 'none';
+              }}
+            />
+          </div>
+        )}
+
+        {/* Text Content */}
+        <div className="flex-1 p-4 min-w-0 flex flex-col justify-center">
+          {/* Title */}
+          <h4
+            className={cn(
+              'text-base! md:text-lg! font-semibold! leading-snug!',
+              'text-gray-900 dark:text-gray-100',
+              'group-hover:text-blue-500 dark:group-hover:text-blue-400',
+              'transition-colors duration-200',
+              'line-clamp-2 m-0! p-0!',
+            )}
+          >
+            {data.title}
+          </h4>
+
+          {/* Description */}
+          {data.description && (
+            <p
+              className={cn(
+                'text-sm! leading-relaxed! mt-1.5! mb-0!',
+                'text-gray-500 dark:text-gray-400',
+                'line-clamp-2',
+              )}
+            >
+              {data.description}
+            </p>
+          )}
+
+          {/* Site info */}
+          <div className="flex items-center gap-2 mt-2.5">
+            {data.favicon && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={data.favicon}
+                alt=""
+                className="w-4 h-4 rounded-sm m-0!"
+                loading="lazy"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = 'none';
+                }}
+              />
+            )}
+            <span className="text-xs! text-gray-400 dark:text-gray-500 truncate">
+              {hostname}
+            </span>
+            <TbExternalLink
+              className={cn(
+                'w-3.5 h-3.5 text-gray-400 dark:text-gray-500 shrink-0',
+                'group-hover:text-blue-400 transition-colors duration-200',
+              )}
+            />
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+}

--- a/src/components/MarkdownRender/LinkPreviewCard.tsx
+++ b/src/components/MarkdownRender/LinkPreviewCard.tsx
@@ -118,7 +118,7 @@ export default function LinkPreviewCard({ url }: LinkPreviewCardProps) {
                 'group-hover:scale-105 transition-transform duration-300',
               )}
               loading="lazy"
-              onError={(e) => {
+              onError={e => {
                 (e.target as HTMLImageElement).style.display = 'none';
               }}
             />
@@ -162,14 +162,12 @@ export default function LinkPreviewCard({ url }: LinkPreviewCardProps) {
                 alt=""
                 className="w-4 h-4 rounded-sm m-0!"
                 loading="lazy"
-                onError={(e) => {
+                onError={e => {
                   (e.target as HTMLImageElement).style.display = 'none';
                 }}
               />
             )}
-            <span className="text-xs! text-gray-400 dark:text-gray-500 truncate">
-              {hostname}
-            </span>
+            <span className="text-xs! text-gray-400 dark:text-gray-500 truncate">{hostname}</span>
             <TbExternalLink
               className={cn(
                 'w-3.5 h-3.5 text-gray-400 dark:text-gray-500 shrink-0',

--- a/src/components/MarkdownRender/index.tsx
+++ b/src/components/MarkdownRender/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
@@ -10,6 +11,8 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { nightOwl } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { TbExternalLink } from 'react-icons/tb';
 import MarkdownImage from './MarkdownImage';
+import LinkPreviewCard from './LinkPreviewCard';
+import { preprocessMarkdownForOg, detectBareUrlInParagraph } from '@/libs/ogLinkPreview';
 
 interface MarkdownRenderProps {
   markdownText: string;
@@ -31,6 +34,8 @@ export default function MarkdownRender({
   const isPost = renderType === 'POST';
   const isProject = renderType === 'PROJECT';
   const isSnippet = renderType === 'SNIPPET';
+
+  const processedMarkdown = preprocessMarkdownForOg(markdownText);
 
   return (
     <div className="markdown-body bg-transparent text-black dark:text-gray-200 tracking-tight text-base md:text-lg">
@@ -83,6 +88,41 @@ export default function MarkdownRender({
               {...props}
             />
           ),
+          // 인라인 <!-- og -->URL 처리: data-link-preview span을 카드로 변환
+          span({ ...props }) {
+            const previewUrl = (props as Record<string, unknown>)['data-link-preview'];
+            if (previewUrl && typeof previewUrl === 'string') {
+              return <LinkPreviewCard url={previewUrl} />;
+            }
+            return <span {...props} />;
+          },
+          // p 내부의 link-preview 마커 또는 독립형 베어 URL → 카드로 교체
+          p({ children, ...props }) {
+            // data-link-preview 마커가 있으면 p 자체를 카드로 교체
+            const childArray = React.Children.toArray(children);
+            for (const child of childArray) {
+              if (React.isValidElement(child)) {
+                const el = child as React.ReactElement<Record<string, unknown>>;
+                const previewUrl = el.props?.['data-link-preview'];
+                if (previewUrl && typeof previewUrl === 'string') {
+                  return <LinkPreviewCard url={previewUrl} />;
+                }
+              }
+            }
+            // 베어 URL 자동 감지 → 링크 유지 + 아래에 카드 추가
+            const { shouldRenderCard, href } = detectBareUrlInParagraph(children);
+            if (shouldRenderCard && href) {
+              return (
+                <>
+                  <p {...props} className={cn(props.className, 'mb-0! pb-0!')}>
+                    {children}
+                  </p>
+                  <LinkPreviewCard url={href} />
+                </>
+              );
+            }
+            return <p {...props}>{children}</p>;
+          },
           a: ({ href, children, ...props }) => (
             <a
               className="text-blue-400 hover:text-blue-300 transition-colors duration-200 items-center mr-1"
@@ -163,7 +203,7 @@ export default function MarkdownRender({
           },
         }}
       >
-        {markdownText}
+        {processedMarkdown}
       </ReactMarkdown>
     </div>
   );

--- a/src/components/PostsPage/NavPostList.tsx
+++ b/src/components/PostsPage/NavPostList.tsx
@@ -29,8 +29,7 @@ export default function NavPostList({
 }: NavPostListProps) {
   // 현재 글을 가운데에 두는 슬라이딩 윈도우 (4번째 글이면 2,3,4,5,6)
   const half = Math.floor(pageSize / 2);
-  const clampStart = (idx: number) =>
-    Math.max(0, Math.min(idx, posts.length - pageSize));
+  const clampStart = (idx: number) => Math.max(0, Math.min(idx, posts.length - pageSize));
   const initialStart = clampStart(currentIndex - half);
   const [start, setStart] = useState(initialStart);
 
@@ -88,7 +87,7 @@ export default function NavPostList({
 
       {/* 포스트 리스트 */}
       <div className="divide-y divide-gray-200 dark:divide-gray-700/30">
-        {visiblePosts.map((post) => {
+        {visiblePosts.map(post => {
           const globalIndex = posts.findIndex(p => p.slug === post.slug);
           const isCurrent = globalIndex === currentIndex;
           return (

--- a/src/components/PostsPage/NavPostList.tsx
+++ b/src/components/PostsPage/NavPostList.tsx
@@ -27,16 +27,17 @@ export default function NavPostList({
   pageSize = 5,
   label,
 }: NavPostListProps) {
-  // 현재 글이 포함된 페이지로 초기화
-  const initialPage = Math.floor(currentIndex / pageSize);
-  const [page, setPage] = useState(initialPage);
+  // 현재 글을 가운데에 두는 슬라이딩 윈도우 (4번째 글이면 2,3,4,5,6)
+  const half = Math.floor(pageSize / 2);
+  const clampStart = (idx: number) =>
+    Math.max(0, Math.min(idx, posts.length - pageSize));
+  const initialStart = clampStart(currentIndex - half);
+  const [start, setStart] = useState(initialStart);
 
-  const totalPages = Math.ceil(posts.length / pageSize);
-  const start = page * pageSize;
   const visiblePosts = posts.slice(start, start + pageSize);
 
-  const canPrev = page > 0;
-  const canNext = page < totalPages - 1;
+  const canPrev = start > 0;
+  const canNext = start + pageSize < posts.length;
 
   return (
     <div
@@ -52,10 +53,10 @@ export default function NavPostList({
           {label || '📝 전체 글'}
         </p>
         {/* 페이지네이션 */}
-        {totalPages > 1 && (
+        {posts.length > pageSize && (
           <div className="flex items-center gap-1">
             <button
-              onClick={() => setPage(p => p - 1)}
+              onClick={() => setStart(s => clampStart(s - pageSize))}
               disabled={!canPrev}
               className={cn(
                 'p-1 rounded transition-colors',
@@ -70,7 +71,7 @@ export default function NavPostList({
               {start + 1}–{Math.min(start + pageSize, posts.length)} / {posts.length}
             </span>
             <button
-              onClick={() => setPage(p => p + 1)}
+              onClick={() => setStart(s => clampStart(s + pageSize))}
               disabled={!canNext}
               className={cn(
                 'p-1 rounded transition-colors',

--- a/src/components/PostsPage/NavPostList.tsx
+++ b/src/components/PostsPage/NavPostList.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import cn from '@yeahx4/cn';
+import { FiChevronLeft, FiChevronRight } from 'react-icons/fi';
+
+export interface NavPostItem {
+  slug: string;
+  title: string;
+}
+
+interface NavPostListProps {
+  /** 전체 포스트 목록 */
+  posts: NavPostItem[];
+  /** 현재 글의 인덱스 */
+  currentIndex: number;
+  /** 한 페이지에 보여줄 글 수 */
+  pageSize?: number;
+  /** 상단 헤더 레이블 */
+  label?: string;
+}
+
+export default function NavPostList({
+  posts,
+  currentIndex,
+  pageSize = 5,
+  label,
+}: NavPostListProps) {
+  // 현재 글이 포함된 페이지로 초기화
+  const initialPage = Math.floor(currentIndex / pageSize);
+  const [page, setPage] = useState(initialPage);
+
+  const totalPages = Math.ceil(posts.length / pageSize);
+  const start = page * pageSize;
+  const visiblePosts = posts.slice(start, start + pageSize);
+
+  const canPrev = page > 0;
+  const canNext = page < totalPages - 1;
+
+  return (
+    <div
+      className={cn(
+        'rounded-2xl overflow-hidden',
+        'border border-gray-200 dark:border-gray-700/40',
+        'bg-gray-50 dark:bg-gray-800/30',
+      )}
+    >
+      {/* 헤더 */}
+      <div className="flex items-center justify-between px-5 py-3 border-b border-gray-200 dark:border-gray-700/40">
+        <p className="text-sm font-medium text-gray-500 dark:text-gray-400 m-0!">
+          {label || '📝 전체 글'}
+        </p>
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setPage(p => p - 1)}
+              disabled={!canPrev}
+              className={cn(
+                'p-1 rounded transition-colors',
+                canPrev
+                  ? 'text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer'
+                  : 'text-gray-300 dark:text-gray-600 cursor-default',
+              )}
+            >
+              <FiChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="text-xs text-gray-400 dark:text-gray-500 min-w-[3rem] text-center">
+              {start + 1}–{Math.min(start + pageSize, posts.length)} / {posts.length}
+            </span>
+            <button
+              onClick={() => setPage(p => p + 1)}
+              disabled={!canNext}
+              className={cn(
+                'p-1 rounded transition-colors',
+                canNext
+                  ? 'text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer'
+                  : 'text-gray-300 dark:text-gray-600 cursor-default',
+              )}
+            >
+              <FiChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 포스트 리스트 */}
+      <div className="divide-y divide-gray-200 dark:divide-gray-700/30">
+        {visiblePosts.map((post) => {
+          const globalIndex = posts.findIndex(p => p.slug === post.slug);
+          const isCurrent = globalIndex === currentIndex;
+          return (
+            <Link
+              key={post.slug}
+              href={`/posts/${post.slug}`}
+              className={cn(
+                'flex items-center gap-3 px-5 py-3 no-underline transition-colors duration-200',
+                isCurrent
+                  ? 'bg-blue-50 dark:bg-blue-900/20 border-l-3 border-blue-500'
+                  : 'hover:bg-gray-100 dark:hover:bg-gray-700/30 border-l-3 border-transparent',
+              )}
+            >
+              <span
+                className={cn(
+                  'text-xs font-mono min-w-[1.5rem] text-center',
+                  isCurrent
+                    ? 'text-blue-500 dark:text-blue-400 font-bold'
+                    : 'text-gray-400 dark:text-gray-500',
+                )}
+              >
+                {globalIndex + 1}
+              </span>
+              <span
+                className={cn(
+                  'text-sm truncate',
+                  isCurrent
+                    ? 'text-blue-600 dark:text-blue-400 font-semibold'
+                    : 'text-gray-700 dark:text-gray-300',
+                )}
+              >
+                {post.title}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PostsPage/PostNav.tsx
+++ b/src/components/PostsPage/PostNav.tsx
@@ -1,0 +1,22 @@
+import NavPostList from './NavPostList';
+import type { PostNavContext } from '@/content/post.service';
+
+interface PostNavProps {
+  context: PostNavContext;
+}
+
+export default function PostNav({ context }: PostNavProps) {
+  const { posts, currentIndex } = context;
+
+  if (posts.length === 0) return null;
+
+  return (
+    <div className="mb-4">
+      <NavPostList
+        posts={posts}
+        currentIndex={currentIndex}
+        label="📝 전체 글"
+      />
+    </div>
+  );
+}

--- a/src/components/PostsPage/PostNav.tsx
+++ b/src/components/PostsPage/PostNav.tsx
@@ -12,11 +12,7 @@ export default function PostNav({ context }: PostNavProps) {
 
   return (
     <div className="mb-4">
-      <NavPostList
-        posts={posts}
-        currentIndex={currentIndex}
-        label="📝 전체 글"
-      />
+      <NavPostList posts={posts} currentIndex={currentIndex} label="📝 전체 글" />
     </div>
   );
 }

--- a/src/components/PostsPage/SeriesNav.tsx
+++ b/src/components/PostsPage/SeriesNav.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import cn from '@yeahx4/cn';
+import type { SeriesContext } from '@/content/post.service';
+import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
+import NavPostList from './NavPostList';
+
+interface SeriesNavProps {
+  context: SeriesContext;
+  variant: 'header' | 'footer';
+}
+
+export default function SeriesNav({ context, variant }: SeriesNavProps) {
+  const { seriesName, posts, currentIndex } = context;
+
+  if (variant === 'header') {
+    return <SeriesHeader seriesName={seriesName} posts={posts} currentIndex={currentIndex} />;
+  }
+
+  // footer
+  return (
+    <div className="mt-16 mb-4">
+      <NavPostList
+        posts={posts}
+        currentIndex={currentIndex}
+        label={`📚 ${seriesName} 시리즈`}
+      />
+    </div>
+  );
+}
+
+/** 제목 아래: 접혀있는 시리즈 목록 (5개씩 보이고 펼치기 가능) */
+function SeriesHeader({
+  seriesName,
+  posts,
+  currentIndex,
+}: {
+  seriesName: string;
+  posts: { slug: string; title: string }[];
+  currentIndex: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const COLLAPSED_COUNT = 5;
+  const needsExpand = posts.length > COLLAPSED_COUNT;
+  const visiblePosts = expanded ? posts : posts.slice(0, COLLAPSED_COUNT);
+
+  return (
+    <div
+      className={cn(
+        'mt-6 rounded-2xl overflow-hidden',
+        'border border-gray-200 dark:border-gray-700/40',
+        'bg-gray-50 dark:bg-gray-800/30',
+      )}
+    >
+      {/* 헤더 */}
+      <div className="px-5 py-3 border-b border-gray-200 dark:border-gray-700/40">
+        <p className="text-sm font-medium text-gray-500 dark:text-gray-400 m-0!">
+          📚 <span className="text-gray-700 dark:text-gray-200 font-semibold">{seriesName}</span>
+          {' '}시리즈 · {currentIndex + 1}/{posts.length}
+        </p>
+      </div>
+
+      {/* 리스트 */}
+      <div className="divide-y divide-gray-200 dark:divide-gray-700/30">
+        {visiblePosts.map((post, i) => {
+          const isCurrent = i === currentIndex;
+          return (
+            <Link
+              key={post.slug}
+              href={`/posts/${post.slug}`}
+              className={cn(
+                'flex items-center gap-3 px-5 py-2.5 no-underline transition-colors duration-200',
+                isCurrent
+                  ? 'bg-blue-50 dark:bg-blue-900/20 border-l-3 border-blue-500'
+                  : 'hover:bg-gray-100 dark:hover:bg-gray-700/30 border-l-3 border-transparent',
+              )}
+            >
+              <span
+                className={cn(
+                  'text-xs md:text-sm font-mono min-w-[1.5rem] text-center',
+                  isCurrent
+                    ? 'text-blue-500 dark:text-blue-400 font-bold'
+                    : 'text-gray-400 dark:text-gray-500',
+                )}
+              >
+                {i + 1}
+              </span>
+              <span
+                className={cn(
+                  'text-sm truncate',
+                  isCurrent
+                    ? 'text-blue-600 dark:text-blue-400 font-semibold'
+                    : 'text-gray-700 dark:text-gray-300',
+                )}
+              >
+                {post.title}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* 펼치기/접기 버튼 */}
+      {needsExpand && (
+        <button
+          onClick={() => setExpanded(v => !v)}
+          className={cn(
+            'w-full flex items-center justify-center gap-1.5 px-5 py-2.5',
+            'text-xs md:text-sm text-gray-400 dark:text-gray-500',
+            'hover:bg-gray-100 dark:hover:bg-gray-700/30',
+            'border-t border-gray-200 dark:border-gray-700/40',
+            'transition-colors cursor-pointer',
+          )}
+        >
+          {expanded ? (
+            <>
+              접기 <FiChevronUp className="w-3.5 h-3.5" />
+            </>
+          ) : (
+            <>
+              {posts.length - COLLAPSED_COUNT}개 더 보기 <FiChevronDown className="w-3.5 h-3.5" />
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/PostsPage/SeriesNav.tsx
+++ b/src/components/PostsPage/SeriesNav.tsx
@@ -22,11 +22,7 @@ export default function SeriesNav({ context, variant }: SeriesNavProps) {
   // footer
   return (
     <div className="mt-16 mb-4">
-      <NavPostList
-        posts={posts}
-        currentIndex={currentIndex}
-        label={`📚 ${seriesName} 시리즈`}
-      />
+      <NavPostList posts={posts} currentIndex={currentIndex} label={`📚 ${seriesName} 시리즈`} />
     </div>
   );
 }
@@ -57,8 +53,8 @@ function SeriesHeader({
       {/* 헤더 */}
       <div className="px-5 py-3 border-b border-gray-200 dark:border-gray-700/40">
         <p className="text-sm font-medium text-gray-500 dark:text-gray-400 m-0!">
-          📚 <span className="text-gray-700 dark:text-gray-200 font-semibold">{seriesName}</span>
-          {' '}시리즈 · {currentIndex + 1}/{posts.length}
+          📚 <span className="text-gray-700 dark:text-gray-200 font-semibold">{seriesName}</span>{' '}
+          시리즈 · {currentIndex + 1}/{posts.length}
         </p>
       </div>
 

--- a/src/content/post.service.ts
+++ b/src/content/post.service.ts
@@ -217,3 +217,96 @@ export const getPostData = async (
     throw new Error('포스트 파일을 읽을 수 없습니다.');
   }
 };
+
+// --- Series Context ---
+
+export interface SeriesPostItem {
+  slug: string;
+  title: string;
+  seriesIndex: number;
+}
+
+export interface SeriesContext {
+  seriesName: string;
+  seriesSlug: string;
+  posts: SeriesPostItem[];
+  currentIndex: number;
+  /** 현재 글 중심 5개 윈도우 (네이버 블로그 스타일) */
+  window: SeriesPostItem[];
+}
+
+export const getSeriesContext = async (
+  seriesSlug: string,
+  currentSlug: string,
+): Promise<SeriesContext | null> => {
+  if (!seriesSlug) return null;
+
+  const { posts, series } = await getPostList();
+
+  const seriesPosts = posts
+    .filter(p => p.meta.series === seriesSlug)
+    .sort((a, b) => a.meta.seriesIndex - b.meta.seriesIndex)
+    .map(p => {
+      if (p.meta.draft) return null;
+      return {
+        slug: p.slug,
+        title: p.meta.title,
+        seriesIndex: p.meta.seriesIndex,
+      }
+    }).filter((p) => p !== null);
+
+  if (seriesPosts.length === 0) return null;
+
+  const currentIndex = seriesPosts.findIndex(p => p.slug === currentSlug);
+  if (currentIndex === -1) return null;
+
+  const seriesInfo = series.find(s => s.seriesSlug === seriesSlug);
+
+  // 5개 윈도우: 현재 글을 가운데에 배치
+  const totalPosts = seriesPosts.length;
+  let windowStart: number;
+
+  if (totalPosts <= 5) {
+    windowStart = 0;
+  } else if (currentIndex <= 2) {
+    windowStart = 0;
+  } else if (currentIndex >= totalPosts - 3) {
+    windowStart = totalPosts - 5;
+  } else {
+    windowStart = currentIndex - 2;
+  }
+
+  const window = seriesPosts.slice(windowStart, windowStart + 5);
+
+  return {
+    seriesName: seriesInfo?.name || seriesSlug,
+    seriesSlug,
+    posts: seriesPosts,
+    currentIndex,
+    window,
+  };
+};
+
+// --- Post Nav Context (전체 글 기준) ---
+
+export interface PostNavContext {
+  posts: SeriesPostItem[];
+  currentIndex: number;
+}
+
+export const getPostNavContext = async (currentSlug: string): Promise<PostNavContext> => {
+  const { posts } = await getPostList();
+  // posts는 날짜 내림차순 정렬 (최신이 먼저)
+  const allPosts: SeriesPostItem[] = posts.map((p, i) => {
+    if (p.meta.draft) return null;
+    return {
+      slug: p.slug,
+      title: p.meta.title,
+      seriesIndex: i,
+    }
+  }).filter((p) => p !== null);
+
+  const currentIndex = allPosts.findIndex(p => p.slug === currentSlug);
+
+  return { posts: allPosts, currentIndex: Math.max(currentIndex, 0) };
+};

--- a/src/content/post.service.ts
+++ b/src/content/post.service.ts
@@ -252,8 +252,9 @@ export const getSeriesContext = async (
         slug: p.slug,
         title: p.meta.title,
         seriesIndex: p.meta.seriesIndex,
-      }
-    }).filter((p) => p !== null);
+      };
+    })
+    .filter(p => p !== null);
 
   if (seriesPosts.length === 0) return null;
 
@@ -297,14 +298,16 @@ export interface PostNavContext {
 export const getPostNavContext = async (currentSlug: string): Promise<PostNavContext> => {
   const { posts } = await getPostList();
   // posts는 날짜 내림차순 정렬 (최신이 먼저)
-  const allPosts: SeriesPostItem[] = posts.map((p, i) => {
-    if (p.meta.draft) return null;
-    return {
-      slug: p.slug,
-      title: p.meta.title,
-      seriesIndex: i,
-    }
-  }).filter((p) => p !== null);
+  const allPosts: SeriesPostItem[] = posts
+    .map((p, i) => {
+      if (p.meta.draft) return null;
+      return {
+        slug: p.slug,
+        title: p.meta.title,
+        seriesIndex: i,
+      };
+    })
+    .filter(p => p !== null);
 
   const currentIndex = allPosts.findIndex(p => p.slug === currentSlug);
 

--- a/src/libs/ogLinkPreview.ts
+++ b/src/libs/ogLinkPreview.ts
@@ -1,0 +1,99 @@
+import React from 'react';
+
+/**
+ * 마크다운 전처리: <!-- og --> / <!-- og-only --> / <!-- no-og --> 코멘트를 처리
+ *
+ * - `<!-- og -->URL` → 원래 링크 유지 + 아래에 카드 표시
+ * - `<!-- og-only -->URL` → 카드만 표시 (원래 링크 숨김)
+ * - `<!-- no-og -->` → 다음 베어 URL의 자동 카드 렌더링 억제
+ */
+export function preprocessMarkdownForOg(text: string): string {
+  // <!-- og-only --> + URL → 카드만 표시 (og-only를 먼저 처리해야 og와 충돌 방지)
+  text = text.replace(
+    /<!--\s*og-only\s*-->\s*(https?:\/\/[^\s<)\]]+)/gi,
+    '<span data-link-preview="$1"></span>',
+  );
+
+  // <!-- og --> + URL → 원래 링크 유지 + 카드 아래에 추가
+  // no-og 마커로 베어 URL 자동감지 억제 + 별도 블록에 카드 삽입
+  text = text.replace(
+    /<!--\s*og\s*-->\s*(https?:\/\/[^\s<)\]]+)/gi,
+    '<span data-og-control="no-og" style="display:none"></span>$1\n\n<span data-link-preview="$1"></span>',
+  );
+
+  // <!-- no-og --> → 자동 감지 억제 마커
+  text = text.replace(
+    /<!--\s*no-og\s*-->/gi,
+    '<span data-og-control="no-og" style="display:none"></span>',
+  );
+
+  return text;
+}
+
+/**
+ * p 태그의 children을 분석하여 베어 URL 자동 감지 여부를 판단
+ * - p 태그에 단일 외부 링크만 있고 href === text인 경우 → 카드 렌더링
+ * - data-og-control="no-og" 마커가 있으면 → 카드 렌더링 제외
+ */
+export function detectBareUrlInParagraph(
+  children: React.ReactNode,
+): { shouldRenderCard: boolean; href: string | null } {
+  const childArray = React.Children.toArray(children);
+
+  let hasNoOgMarker = false;
+  let linkHref: string | null = null;
+  let linkChildText: string | null = null;
+  let hasOtherContent = false;
+
+  for (const child of childArray) {
+    if (!React.isValidElement(child)) {
+      if (typeof child === 'string' && child.trim()) {
+        hasOtherContent = true;
+      }
+      continue;
+    }
+
+    const el = child as React.ReactElement<Record<string, unknown>>;
+
+    // no-og 마커 감지
+    if (el.props?.['data-og-control'] === 'no-og') {
+      hasNoOgMarker = true;
+      continue;
+    }
+
+    // link-preview 마커는 무시 (span 컴포넌트에서 별도 처리)
+    if (el.props?.['data-link-preview']) {
+      continue;
+    }
+
+    // br 무시
+    if (el.type === 'br') {
+      continue;
+    }
+
+    // 링크 감지 (커스텀 components.a 사용 시 el.type이 함수이므로 props로 감지)
+    if (el.props?.href && typeof el.props.href === 'string') {
+      if (linkHref) {
+        hasOtherContent = true;
+        continue;
+      }
+      linkHref = el.props.href as string;
+      const linkChildren = React.Children.toArray(el.props.children as React.ReactNode);
+      const firstText = linkChildren.find((c): c is string => typeof c === 'string');
+      if (firstText) {
+        linkChildText = firstText;
+      }
+      continue;
+    }
+
+    hasOtherContent = true;
+  }
+
+  if (!linkHref || hasOtherContent || hasNoOgMarker) {
+    return { shouldRenderCard: false, href: null };
+  }
+
+  // 베어 URL: href === link text
+  const isBareUrl = linkChildText === linkHref && linkHref.startsWith('http');
+  return { shouldRenderCard: isBareUrl, href: isBareUrl ? linkHref : null };
+}

--- a/src/libs/ogLinkPreview.ts
+++ b/src/libs/ogLinkPreview.ts
@@ -35,9 +35,10 @@ export function preprocessMarkdownForOg(text: string): string {
  * - p 태그에 단일 외부 링크만 있고 href === text인 경우 → 카드 렌더링
  * - data-og-control="no-og" 마커가 있으면 → 카드 렌더링 제외
  */
-export function detectBareUrlInParagraph(
-  children: React.ReactNode,
-): { shouldRenderCard: boolean; href: string | null } {
+export function detectBareUrlInParagraph(children: React.ReactNode): {
+  shouldRenderCard: boolean;
+  href: string | null;
+} {
   const childArray = React.Children.toArray(children);
 
   let hasNoOgMarker = false;


### PR DESCRIPTION

## ✨ 외부 링크 OG 미리보기 카드 추가

- resolve #27 

마크다운 내 외부 URL을 Open Graph 메타데이터 기반 카드로 렌더링하는 기능을 추가했습니다.

### 주요 기능

- **베어 URL 자동 감지**: 단독 줄에 URL만 작성하면 링크 + 아래에 OG 카드 자동 표시
- **`<!-- og -->`**: 원래 링크 유지 + 아래에 OG 카드 추가
- **`<!-- og-only -->`**: 카드만 표시 (원래 링크 숨김)
- **`<!-- no-og -->`**: 카드 렌더링 억제 (일반 링크로 표시)

### 구현 내용

| 파일 | 설명 |
|---|---|
| [src/app/api/og/route.ts](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/app/api/og/route.ts:0:0-0:0) | OG 메타데이터 스크랩 API Route (정규식 파싱, 10s 타임아웃, CDN 캐싱) |
| [src/components/MarkdownRender/LinkPreviewCard.tsx](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/components/MarkdownRender/LinkPreviewCard.tsx:0:0-0:0) | OG 카드 클라이언트 컴포넌트 (스켈레톤 로딩, 에러 폴백) |
| [src/libs/ogLinkPreview.ts](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/libs/ogLinkPreview.ts:0:0-0:0) | 마크다운 전처리 + 베어 URL 감지 로직 |
| [src/components/MarkdownRender/index.tsx](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/components/MarkdownRender/index.tsx:0:0-0:0) | [span](cci:1://file:///c:/Users/pocky/MyWorkSpace/blog/src/components/MarkdownRender/index.tsx:90:10-97:11)/`p` 커스텀 렌더러 연동 |
| [README.md](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/README.md:0:0-0:0) | 링크 프리뷰 사용법 문서 추가 |

### 기술적 세부사항

- 외부 라이브러리 없이 정규식으로 OG 메타 파싱
- `<!-- og -->` 코멘트를 전처리 단계에서 `data-link-preview` span으로 변환하여 인라인/독립형 모두 지원
- `react-markdown` 커스텀 컴포넌트에서 `el.type` 대신 `el.props` 기반 감지 (커스텀 렌더러 호환)
- `<p>` 내부 hydration 에러 방지를 위해 `p` 렌더러에서 카드 마커 우선 감지

### 스크린샷

<img width="806" height="572" alt="image" src="https://github.com/user-attachments/assets/9eb198b1-2408-466a-8eb7-df02b5ca8a27" />


---

## ✨ 시리즈 & 전체글 네비게이션 추가

글의 시리즈 컨텍스트와 전체 글 목록을 탐색할 수 있는 네비게이션 UI를 추가했습니다.

### 주요 기능

- **시리즈 헤더 (제목 아래)**: 전체 시리즈 목록을 5개까지 보여주고, 나머지는 접혀있는 아코디언 형태
- **시리즈 푸터 (글 아래)**: 5개씩 페이지네이션으로 시리즈 내 글 탐색 (`«`/`»` 버튼)
- **전체글 네비게이션 (글 아래)**: 날짜순 전체 글 목록을 5개씩 페이지네이션으로 탐색
- 현재 글은 파란색 하이라이트로 구분
- 초고(`draft`) 글은 네비게이션에서 제외

### 구현 내용

| 파일 | 설명 |
|---|---|
| [src/content/post.service.ts](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/content/post.service.ts:0:0-0:0) | [getSeriesContext()](cci:1://file:///c:/Users/pocky/MyWorkSpace/blog/src/content/post.service.ts:237:0-287:2), [getPostNavContext()](cci:1://file:///c:/Users/pocky/MyWorkSpace/blog/src/content/post.service.ts:296:0-311:2) 서비스 함수 추가. 시리즈는 `seriesIndex` 기준 정렬, 전체글은 날짜 내림차순 정렬하여 현재 글 중심의 컨텍스트 데이터 제공 |
| [src/components/PostsPage/NavPostList.tsx](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/components/PostsPage/NavPostList.tsx:0:0-0:0) | 공통 페이지네이션 리스트 클라이언트 컴포넌트 (시리즈/전체글 모두 사용) |
| [src/components/PostsPage/SeriesNav.tsx](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/components/PostsPage/SeriesNav.tsx:0:0-0:0) | 시리즈 네비게이션 (`header`: 접기/펼치기, `footer`: NavPostList 활용) |
| [src/components/PostsPage/PostNav.tsx](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/components/PostsPage/PostNav.tsx:0:0-0:0) | 전체글 네비게이션 (NavPostList 활용) |
| [src/app/posts/[id]/page.tsx](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/app/posts/%5Bid%5D/page.tsx:0:0-0:0) | 서비스 함수 호출 및 컴포넌트 통합 |

### 기술적 세부사항

- [post.service.ts](cci:7://file:///c:/Users/pocky/MyWorkSpace/blog/src/content/post.service.ts:0:0-0:0)에서 [getSeriesContext()](cci:1://file:///c:/Users/pocky/MyWorkSpace/blog/src/content/post.service.ts:237:0-287:2)는 동일 시리즈의 글을 `seriesIndex`로 정렬 후 `SeriesPostItem[]` + `currentIndex`로 반환
- [getPostNavContext()](cci:1://file:///c:/Users/pocky/MyWorkSpace/blog/src/content/post.service.ts:296:0-311:2)는 전체 글을 날짜순 정렬하여 동일한 인터페이스로 반환, 두 서비스 모두 `draft` 글 필터링 적용
- [NavPostList](cci:1://file:///c:/Users/pocky/MyWorkSpace/blog/src/components/PostsPage/NavPostList.tsx:23:0-129:1)를 공통 클라이언트 컴포넌트로 분리하여 시리즈/전체글 모두 동일한 5개 페이지네이션 UI 재사용
- 현재 글이 중앙에 오는 슬라이딩 윈도우 방식으로 표시

### 스크린샷

- 상단 시리즈 컴포넌트
<img width="829" height="493" alt="image" src="https://github.com/user-attachments/assets/3f90d9af-fca9-42f7-b248-e11e8456670a" />
<img width="801" height="701" alt="image" src="https://github.com/user-attachments/assets/807fef7d-61e5-43b0-b334-b004d658b649" />


- 하단 글목록 컴포넌트
<img width="798" height="607" alt="image" src="https://github.com/user-attachments/assets/aa385a38-d53a-45f3-b0f1-6f5651086f5a" />
